### PR TITLE
Change docker-compose.yml to prod settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 config.js
+docker-compose.override.yml
 *.log

--- a/README.md
+++ b/README.md
@@ -150,13 +150,18 @@ Wikiless should now be running at <http://localhost:8080>.
 
 ### Docker & docker compose
 
-You can build a production image by running `docker build .` in the repo's root.
-
-For development, there's a `docker-compose.yml` that mounts the app code (for hot reload of code changes) and default config. Before running it, you need to install the dependencies:
+Run wikiless in production with docker compose:
 
 ```
-$ docker-compose run --rm web npm install --no-optionals
-$ docker-compose up
+$ docker compose up
+```
+
+For development, there's a `docker-compose.dev.yml` that mounts the app code (for hot reload of code changes) and default config. Before running it, you need to install the dependencies:
+
+```
+$ cp docker-compose.dev.yml docker-compose.override.yml
+$ docker compose run --rm web npm install --no-optionals
+$ docker compose up
 ```
 
 If you are experiencing errors with Redis not connecting, you might want to try the [alternative docker-compose.yml](https://github.com/JarbasAl/wikiless-docker).

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  web:
+    image: node:16-alpine
+    volumes:
+      - .:/wikiless
+      - ./config.js.template:/wikiless/config.js
+      - node_modules:/wikiless/node_modules
+    working_dir: /wikiless
+    command: npm start
+volumes:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,13 @@
 version: "3.9"
 services:
   web:
-    image: node:16-alpine
+    image: ghcr.io/metastem/wikiless:latest
     environment:
-      REDIS_HOST: redis
-    volumes:
-      - .:/app
-      - ./config.js.template:/app/config.js
-      - node_modules:/app/node_modules
-    working_dir: /app
-    command: npm start
+      # see config.js.template for more settings
+      DOMAIN: wikiless.example.org
+      HTTP_ADDR: 0.0.0.0
+      REDIS_URL: redis://redis
     ports:
       - 8080:8080
   redis:
     image: "redis:alpine"
-volumes:
-  node_modules:


### PR DESCRIPTION
**docker-compose.yml** now features "production" settings:
* uses `ghcr.io/metastem/wikiless:latest` image
* doesn't mount src or node_modules
* removed `workdir` and `command` as they're already set in docker image
* set HTTP_ADDR to 0.0.0.0

**docker-compose.dev.yml** can be used as override for development (https://docs.docker.com/compose/extends/#multiple-compose-files):
* either copy/symlink docker-compose.dev.yml to docker-compose.override.yml 
* or start stuff with `docker compose -f docker-compose.yml -f docker-compose.dev.yml ...`

Note: I had to change REDIS_HOST from `redis` to `redis://redis` because wikiless was complaining:

```
wikiless-web-1    | TypeError [ERR_INVALID_URL]: Invalid URL
wikiless-web-1    |     at new NodeError (node:internal/errors:387:5)
wikiless-web-1    |     at URL.onParseError (node:internal/url:565:9)
...
wikiless-web-1    |     at /wikiless/src/wikiless.js:17:20 {
wikiless-web-1    |   input: 'redis',
wikiless-web-1    |   code: 'ERR_INVALID_URL'
```

Works on my machine :crossed_fingers: 