### PR TITLE
Add lang parameter to forms

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -140,6 +140,12 @@ module.exports = function(redis) {
         }
       }
 
+      // add the lang query param to forms
+      let forms = data.html.querySelectorAll('form')
+      for(let i = 0; i < forms.length; i++) {
+        forms[i].insertAdjacentHTML('afterbegin', `<input type="hidden" name="lang" value="${lang}">`)
+      }
+
       // remove #p-wikibase-otherprojects
       let wikibase_links = data.html.querySelector('#p-wikibase-otherprojects')
       if(wikibase_links) {
@@ -200,18 +206,6 @@ module.exports = function(redis) {
       // replace wiki links
       const wiki_href_regx = /(href=\"(https:|http:|)\/\/([A-z.-]+\.)?(wikipedia.org|wikimedia.org|wikidata.org|mediawiki.org))/gm
       data.html = data.html.replace(wiki_href_regx, 'href="')
-
-      /**
-      * If we are on DownloadAsPdf page, we have to inject a input which
-      * holds the language value. Without this input, we can't access the
-      * language (not avail from the POST data).
-      * See more on https://codeberg.org/orenom/Wikiless/issues/9
-      */
-      if(url.includes('%3ADownloadAsPdf')) {
-        let lang_input = `<input type='hidden' name='lang' value='${lang}'>`
-        let replace_str = `<input type='hidden' name='page'`
-        data.html = data.html.replace(replace_str, `${lang_input}${replace_str}`)
-      }
 
       try {
         if(redis.isOpen === false) {


### PR DESCRIPTION
This PR adds `lang` parameter to each form as a hidden value, which fixes searching when using non-default languages.

Currently, trying to search when using a language other than default causes the website to redirect to the home page in default language. The reason behind it is that search action submits a form, which does not contain `lang` value - because of that, search URL also does not contain this parameter, and Wikiless instance receives no information about what language to search in. Furthermore, each language has the value of URL parameter `title` translated (which, in English, is set to `Special:Search`) - when a value is used outside the language it was intended for, HTTP 404 error occurs, which is handled by falling back to the main page.

Also, it seems like there was a similar issue with downloading the article as PDF - as `lang` parameter is added to every form present on the page, the previous fix is no longer needed. I could not test this feature, though, as trying to download the article results in `INVALID_HTML` error even when using code from the `main` branch.