### PR TITLE
harden dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM node:16-alpine
+FROM node:16-alpine AS build
 WORKDIR /wikiless
 COPY . /wikiless
 RUN npm install --no-optional
-COPY config.js.template config.js
-CMD npm start
 
+FROM gcr.io/distroless/nodejs:16
+COPY --from=build /wikiless /wikiless
+WORKDIR /wikiless
+COPY config.js.template config.js
+CMD ["src/wikiless.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: "3.9"
 services:
+
   web:
     image: ghcr.io/metastem/wikiless:latest
     environment:
@@ -9,5 +10,28 @@ services:
       REDIS_URL: redis://redis
     ports:
       - 8080:8080
+    user: 65534:65534
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    networks:
+      - wikiless
+
   redis:
     image: "redis:alpine"
+    container_name: redis
+    user: nobody
+    read_only: true
+    tmpfs:
+      - /data:size=10M,mode=0770,uid=65534,gid=65534,noexec,nosuid,nodev
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    networks:
+      - wikiless
+
+networks:
+  wikiless:


### PR DESCRIPTION
Instead of doing a blank install in an Alpine container, we have access to "distroless" images. What these are very basic containers that only have one job: run the application. You can read more here: https://github.com/GoogleContainerTools/distroless.

When we build with these distroless containers, it results in a smaller footprint and a more secure container, i.e. there's no shell, package manager, it'd be hard to break out of a distroless container if somehow a bug resulted in an RCE.

With this in mind, we can also harden the `docker-compose.yml` as well:

- `user: nobody`: the least privileged account.
- `read_only: true`: this container doesn't write anything to the filesystem, this removes a vector.
- `security_opt`: disallows the container to grab more privileges.
- `cap_drop`: this container doesn't need any capabilities, drop them.
- `networks`: put `wikiless` into its own network so it cannot see other containers by default.