### PR TITLE
Added Redis Unix Socket Support

### DIFF
--- a/config.js.template
+++ b/config.js.template
@@ -25,6 +25,7 @@ const config = {
   */
   redis_url: process.env.REDIS_URL || process.env.REDIS_HOST || 'redis://127.0.0.1:6379',
   redis_password: process.env.REDIS_PASSWORD,
+  redis_path: process.env.REDIS_PATH,
   
   /**
   * You might need to change these configs below if you host through a reverse

--- a/src/wikiless.js
+++ b/src/wikiless.js
@@ -11,7 +11,10 @@ const bodyParser = require('body-parser')
 const redis = (() => {
   const redisOptions = {
     url: config.redis_url,
-    password: config.redis_password
+    password: config.redis_password,
+    socket: {
+      path: config.redis_path,
+    }
   }
 
   const client = r.createClient(redisOptions)


### PR DESCRIPTION
Allows for the use of redis unix sockets by specifying the path in the docker environmental variable REDIS_PATH i.e.
REDIS_PATH = /tmp/redis.sock