### PR TITLE
remove user and read_only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       REDIS_URL: redis://redis
     ports:
       - 8080:8080
-    user: 65534:65534
-    read_only: true
     security_opt:
       - no-new-privileges:true
     cap_drop:


### PR DESCRIPTION
For some reason, `read_only` is affecting the ability of the wikiless to show images.

Removed as well as `user` (redundency)