### PR TITLE
fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,6 @@ services:
         ipv4_address: 172.4.0.6
     environment:
       REDIS_HOST: redis://172.4.0.5:6379
-      THEME: dark  # change to light if you do not want dark by default
-      HTTP_ADDR: 0.0.0.0 # don't touch
-      DEFAULT_LANG: en # change to any language you want
-      DOMAIN: changethis # set this to your domain do not add http://
-      WIKIPAGE_CACHE_EXPIRATION: 3600
-      wikimedia_useragent: Wikiless media proxy bot (https://github.com/Metastem/wikiless) 
     ports:
       - "127.0.0.1:8180:8080" # change port if needed
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,14 @@ services:
         ipv4_address: 172.4.0.6
     environment:
       REDIS_HOST: redis://172.4.0.5:6379
-      THEME: dark
-      HTTP_ADDR: 0.0.0.0
-      DEFAULT_LANG: en
-      DOMAIN: changethis
-      WIKIPAGE_CACHE_EXPIRATION: 60 * 60 * 1
-      wikimedia_useragent: Wikiless media proxy bot (https://github.com/Metastem/wikiless)
+      THEME: dark  # change to light if you do not want dark by default
+      HTTP_ADDR: 0.0.0.0 # don't touch
+      DEFAULT_LANG: en # change to any language you want
+      DOMAIN: changethis # set this to your domain do not add http://
+      WIKIPAGE_CACHE_EXPIRATION: 3600
+      wikimedia_useragent: Wikiless media proxy bot (https://github.com/Metastem/wikiless) 
     ports:
-      - "127.0.0.1:8180:8080"
-    read_only: true
+      - "127.0.0.1:8180:8080" # change port if needed
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
-version: "3.9"
+version: "3.7"
 
 services:
   wikiless:
-    # build from source
-    #build: .
-    image: wikiless:latest
+    build: .
     restart: always
     networks:
       wikiless_net:


### PR DESCRIPTION
— removed read_only: true (causing bad gateway)
— give me detail for the noobs

NOTE: If you're using docker, you need wikiless.config, Only use it to add it to your docker-compose environment. But I added the recommended settings for you so you require the config file anyway.