### PR TITLE
Update the docker compose file to not require cloning the repo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,13 @@ version: "3.7"
 
 services:
   wikiless:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    build: https://github.com/Metastem/wikiless.git
+    # Use the one below if you wish to use the cloned repo
+    #build:
+    #  context: .
+    #  dockerfile: Dockerfile
+    
+    # Outdated image below
     #image: ghcr.io/metastem/wikiless:latest
     restart: always
     networks:


### PR DESCRIPTION
This PR makes it so you don't need to clone the entire repo to use the project, this makes it much easier to use in external docker managers (eg: portainer)