### PR TITLE
[chore] improve docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   wikiless:
     build:
@@ -9,10 +7,9 @@ services:
     hostname: wikiless
     restart: always
     networks:
-      wikiless_net:
-        ipv4_address: 172.4.0.6
+      - wikiless_net
     environment:
-      REDIS_HOST: redis://172.4.0.5:6379
+      REDIS_HOST: redis://wikiless_redis:6379
     ports:
       - "127.0.0.1:8180:8080" # change port if needed
     security_opt:
@@ -28,8 +25,7 @@ services:
     image: redis:latest
     restart: always
     networks:
-      wikiless_net:
-        ipv4_address: 172.4.0.5
+      - wikiless_net
     user: nobody
     read_only: true
     security_opt:
@@ -45,6 +41,3 @@ services:
 
 networks:
   wikiless_net:
-    ipam:
-      config:
-        - subnet: 172.4.0.0/16


### PR DESCRIPTION
- removing the version attribute as it was deprecated.

- changing the docker network to automatically resolve via internal DNS instead of a hard coded IP. The previously used network (172.4.0.0/16) is publicly routable because it is not part of the class B networks.